### PR TITLE
Feature: Separated Selected Command from Command Selection Datalist (#7)

### DIFF
--- a/Client/src/main/libs/filesys/read-commands.ts
+++ b/Client/src/main/libs/filesys/read-commands.ts
@@ -13,6 +13,9 @@ function areValidParameters(params?: Array<ParamStruct>): boolean {
         if(!param.default) {
             continue;
         }
+        /* Despite the linter saying that these conditions are always false because of typing, this struct was read
+           from a file and is being validated here. Better types should be used here for the unvalidated struct so that
+           the linter understands */
         switch (param.type) {
             case "int":
             case "float":  if (typeof param.default !== "number") return false; break;

--- a/Client/src/main/libs/filesys/read-commands.ts
+++ b/Client/src/main/libs/filesys/read-commands.ts
@@ -7,20 +7,18 @@ function areValidParameters(params?: Array<ParamStruct>): boolean {
     }
 
     for(let param of params) {
-        if(!param.name) {
+        if(!param.name || !param.type) {
             return false;
         }
         if(!param.default) {
             continue;
         }
-        /* Despite the linter saying that these conditions are always false because of typing, this struct was read
-           from a file and is being validated here. Better types should be used here for the unvalidated struct so that
-           the linter understands */
+
         switch (param.type) {
             case "int":
-            case "float":  if (typeof param.default !== "number") return false; break;
-            case "bool":   if (typeof param.default !== "boolean") return false; break;
-            case "string": if (typeof param.default !== "string") return false; break;
+            case "float":  if (typeof (param.default as unknown) !== "number") return false; break;
+            case "bool":   if (typeof (param.default as unknown) !== "boolean") return false; break;
+            case "string": if (typeof (param.default as unknown) !== "string") return false; break;
         }
     }
     return true;

--- a/Client/src/renderer/components/DisconnectButton.vue
+++ b/Client/src/renderer/components/DisconnectButton.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { defineEmits } from 'vue';
-
 const emit = defineEmits(['disconnect']);
 
 const emitDisconnect = (): void => {

--- a/Client/src/renderer/components/InputField.vue
+++ b/Client/src/renderer/components/InputField.vue
@@ -57,6 +57,9 @@ onMounted(() => {
 
 let timeout = -1;
 const onInputEvent = () => {
+    if (props.debounce === -1)
+        return;
+
     clearTimeout(timeout);
 
     timeout = setTimeout(() => {

--- a/Client/src/renderer/components/InputField.vue
+++ b/Client/src/renderer/components/InputField.vue
@@ -50,11 +50,7 @@ const props = defineProps({
 const isUsingVModel = ref(false);
 watch(
     () => props.modelValue,
-    (newValue) => {
-        if (newValue !== undefined) {
-            isUsingVModel.value = true;
-        }
-    },
+    (newValue) => isUsingVModel.value = newValue !== undefined,
     {immediate: true}
 );
 

--- a/Client/src/renderer/components/InputField.vue
+++ b/Client/src/renderer/components/InputField.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import {getCurrentInstance, onMounted, PropType, ref} from 'vue';
+import {getCurrentInstance, onMounted, PropType, ref, watch} from 'vue';
 import {validateRules} from '@renderer/util/form/form-rules';
+
 const {setTimeout, clearTimeout} = window;
 
 const props = defineProps({
@@ -39,7 +40,24 @@ const props = defineProps({
         type: Number,
         default: 300,
     },
+    modelValue: {
+        type: [String, Number, Boolean, Object, Array],
+        required: false,
+    },
 });
+
+/* Detect if the v-model was used on the input field - ChatGpt */
+const isUsingVModel = ref(false);
+watch(
+    () => props.modelValue,
+    (newValue) => {
+        if (newValue !== undefined) {
+            isUsingVModel.value = true;
+        }
+    },
+    {immediate: true}
+);
+
 const modelValue = defineModel();
 
 const emit = defineEmits(['update:modelValue']);
@@ -57,7 +75,7 @@ onMounted(() => {
 
 let timeout = -1;
 const onInputEvent = () => {
-    if (props.debounce === -1)
+    if (isUsingVModel.value === false)
         return;
 
     clearTimeout(timeout);
@@ -75,7 +93,7 @@ const validate = (updateErrors: boolean = true) => {
     if (updateErrors) {
         errorMessages.value = [];
 
-        if (! formResult.valid) {
+        if (!formResult.valid) {
             errorMessages.value.push(...formResult.errors);
         }
     }

--- a/Client/src/renderer/views/command-centre/CommandCentre.vue
+++ b/Client/src/renderer/views/command-centre/CommandCentre.vue
@@ -66,16 +66,16 @@ const sendCommand = async () => {
     if (!valid)
         return;
 
-    setCommandCooldown();
-
-    setText("Command Sent!");
-
     const params = getParamsFromInputs();
     if (params === null) {
         return;
     }
 
+    setCommandCooldown();
+
     await UserServerAction.issueCommand(commandId.value, params);
+
+    setText("Command Sent!");
 
     clearInputs([commandSelectionInput.value]);
     commandParamValues.value = [];

--- a/Client/src/renderer/views/command-centre/CommandCentre.vue
+++ b/Client/src/renderer/views/command-centre/CommandCentre.vue
@@ -287,7 +287,6 @@ window.addEventListener('keyup', (event: KeyboardEvent) => {
                                     ref="commandSelectionInput"
                                     list="commands"
                                     placeholder="Select Command"
-                                    :debounce="-1"
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
Main objective (see title) is to separate the selected command from the datalist. 
Making it easier to select a different command without needing to clear the datalist.

---

Also includes: 

- A single small feature for the `InputField` component
  - Automatically disabled the `onInput` event handler when `v-model` is not used
- Two new hotkeys for command centre:
  - `CTRL + Q`: Focus Command Selection Input Field
  - `CTRL + ENTER`: Send Command (takes cooldown into account)
- A single feature for the datalist behaviour itself
  - When `tab` or `enter` is pressed (datalist is changed) but no option matches exactly, it selects the first option that partially matches the current query of the user

